### PR TITLE
fix: Update portfolio link click handler for full page reload

### DIFF
--- a/src/components/Navigation.vue
+++ b/src/components/Navigation.vue
@@ -19,10 +19,12 @@ const closeMenu = () => {
 	isMenuOpen.value = false
 }
 
-const reloadPage = (event: Event) => {
+const handlePortfolioClick = (event: Event) => {
 	event.preventDefault()
-	window.location.reload()
+	// Use location.href for a full page reload that works in production
+	window.location.href = window.location.origin
 }
+
 
 const handleScroll = () => {
 	// Use a smaller threshold for faster transition
@@ -55,7 +57,7 @@ watch(
 			<div class="flex justify-between h-14">
 				<div class="flex items-center">
 					<div class="flex-shrink-0 flex items-center">
-						<a href="/" @click="reloadPage" class="group text-xl font-bold relative">
+						<a href="/" @click="handlePortfolioClick" class="group text-xl font-bold relative cursor-pointer">
 							<span
 								class="text-transparent bg-clip-text bg-gradient-to-r from-indigo-400 to-purple-400 group-hover:from-purple-400 group-hover:to-pink-400 transition-all duration-500"
 							>


### PR DESCRIPTION
This pull request updates the navigation behavior for the portfolio link in the `Navigation.vue` component. The main change is replacing the previous page reload logic with a more robust method that ensures a full page reload works correctly in production environments.

Navigation behavior improvements:

* Renamed the `reloadPage` function to `handlePortfolioClick` and updated its logic to use `window.location.href = window.location.origin` for a reliable full page reload.
* Updated the portfolio link's click handler to use the new `handlePortfolioClick` function and added a `cursor-pointer` class for better UX.