### PR TITLE
feat: add video demo functionality for portfolio projects

### DIFF
--- a/src/constants/projects.ts
+++ b/src/constants/projects.ts
@@ -77,7 +77,7 @@ export const PROJECTS_METADATA: ProjectMetadata[] = [
 			'https://via.placeholder.com/800x600',
 		],
 		sourceUrl: 'https://github.com/DenisChpt/portfolio',
-		liveUrl: 'https://denischaput.dev',
+		liveUrl: '/videos/portfolio.mov',  // Video demo of the portfolio
 		status: 'active',
 	},
 ]


### PR DESCRIPTION
This pull request updates the project portfolio to support video demos for live projects, specifically enabling the portfolio project to display a video demo instead of linking to an external site. The modal logic and UI are enhanced to allow seamless switching between project details and video playback, including custom controls and improved accessibility.

**Video Demo Integration:**

* Changed the `liveUrl` for the portfolio project in `PROJECTS_METADATA` to point to a local video file instead of an external URL.
* Added logic to detect if a project's `liveUrl` is a video file and, if so, display a video player in the modal with playback controls and a custom header for navigation. [[1]](diffhunk://#diff-019ac5aa3a8c242eab6d99828ba6c220e95b5a9f7c85338607b104e39a268335L212-R252) [[2]](diffhunk://#diff-019ac5aa3a8c242eab6d99828ba6c220e95b5a9f7c85338607b104e39a268335L548-R625)

**Modal and UI Enhancements:**

* Introduced `modalMode` state to toggle between card and video views, and provided functions to switch modes and reset on close. [[1]](diffhunk://#diff-019ac5aa3a8c242eab6d99828ba6c220e95b5a9f7c85338607b104e39a268335R27-R30) [[2]](diffhunk://#diff-019ac5aa3a8c242eab6d99828ba6c220e95b5a9f7c85338607b104e39a268335L212-R252)
* Updated the "View Live Demo" button to trigger video playback when appropriate, with dynamic icons for video vs. link, and replaced anchor tags with buttons for better accessibility and control. [[1]](diffhunk://#diff-019ac5aa3a8c242eab6d99828ba6c220e95b5a9f7c85338607b104e39a268335L641-R733) [[2]](diffhunk://#diff-019ac5aa3a8c242eab6d99828ba6c220e95b5a9f7c85338607b104e39a268335L662-R745)

**Styling Improvements:**

* Added scoped styles for the video mode, including custom media controls and fullscreen handling for a polished viewing experience.